### PR TITLE
Modify rubric form validation

### DIFF
--- a/app/protected/org/[orgId]/new-opening/page.tsx
+++ b/app/protected/org/[orgId]/new-opening/page.tsx
@@ -24,6 +24,8 @@ interface EligibleReviewer {
     | null;
 }
 
+const MAX_RUBRIC_SCORE = 1_000_000_000_000;
+
 export default function NewOpeningPage() {
   const params = useParams<{ orgId: string }>();
   const orgId = params.orgId;
@@ -88,6 +90,42 @@ export default function NewOpeningPage() {
       return;
     }
 
+    const normalizedRubric = rubric.map((r) => ({
+      ...r,
+      name: r.name.trim(),
+      description: r.description.trim(),
+      max_val: Number(r.max_val),
+    }));
+
+    const hasRubricContent = normalizedRubric.some(
+      (r) => r.name !== "" || r.description !== "" || r.max_val !== 10,
+    );
+
+    if (hasRubricContent) {
+      if (normalizedRubric.some((r) => !r.name)) {
+        setError("All criteria must have a name.");
+        return;
+      }
+
+      const normalizedNames = normalizedRubric.map((r) =>
+        r.name.toLowerCase(),
+      );
+      if (new Set(normalizedNames).size !== normalizedNames.length) {
+        setError("Criteria names must be unique.");
+        return;
+      }
+
+      if (normalizedRubric.some((r) => r.max_val <= 0)) {
+        setError("Max score must be greater than 0.");
+        return;
+      }
+
+      if (normalizedRubric.some((r) => r.max_val > MAX_RUBRIC_SCORE)) {
+        setError("Max score must be less than or equal to 1,000,000,000,000.");
+        return;
+      }
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -104,8 +142,8 @@ export default function NewOpeningPage() {
             : null,
           status: formData.status,
           rubric:
-            rubric.filter((r) => r.name.trim()).length > 0
-              ? rubric.map((r) => ({ ...r, max_val: Number(r.max_val) || 0 }))
+            hasRubricContent
+              ? normalizedRubric
               : undefined,
         }),
       });
@@ -456,14 +494,20 @@ export default function NewOpeningPage() {
           <button
             type="button"
             onClick={() => {
-              setRubricOpen(!rubricOpen);
-              if (!rubricOpen && rubric.length === 0) {
+              if (rubricOpen) {
+                setRubric([]);
+                setRubricOpen(false);
+                return;
+              }
+
+              setRubricOpen(true);
+              if (rubric.length === 0) {
                 setRubric([{ name: "", max_val: 10, description: "" }]);
               }
             }}
             className="text-sm font-medium text-owl-purple hover:text-owl-purple/80 transition-colors"
           >
-            {rubricOpen ? "Hide Rubric" : "Add Rubric"}
+            {rubricOpen ? "Delete Rubric" : "Add Rubric"}
           </button>
 
           {rubricOpen && (
@@ -516,7 +560,7 @@ export default function NewOpeningPage() {
                     <Input
                       type="number"
                       min="1"
-                      max="100"
+                      max={MAX_RUBRIC_SCORE}
                       value={item.max_val}
                       onChange={(e) => {
                         const updated = [...rubric];

--- a/app/protected/org/[orgId]/opening/[openingId]/rubric/components/RubricSettingsForm.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/rubric/components/RubricSettingsForm.tsx
@@ -9,7 +9,7 @@ import { Loading01 } from "@untitled-ui/icons-react";
 
 interface Rubric {
   name: string;
-  max_val: number;
+  max_val: number | string;
   description: string;
 }
 
@@ -18,6 +18,8 @@ interface RubricSettingsFormProps {
   openingId: string;
   initialRubric: Rubric[];
 }
+
+const MAX_RUBRIC_SCORE = 1_000_000_000_000;
 
 export function RubricSettingsForm({
   orgId,
@@ -36,7 +38,10 @@ export function RubricSettingsForm({
   ) => {
     const updated = [...rubric];
     if (field === "max_val") {
-      updated[index] = { ...updated[index], [field]: Number(value) };
+      updated[index] = {
+        ...updated[index],
+        [field]: value === "" ? "" : Number(value),
+      };
     } else {
       updated[index] = { ...updated[index], [field]: value as string };
     }
@@ -50,12 +55,32 @@ export function RubricSettingsForm({
   const handleSave = async () => {
     setError(null);
 
-    if (rubric.some((r) => !r.name.trim())) {
+    const normalizedRubric = rubric.map((r) => ({
+      name: r.name.trim(),
+      description: r.description.trim(),
+      max_val: Number(r.max_val),
+    }));
+
+    if (normalizedRubric.some((r) => !r.name)) {
       setError("All criteria must have a name.");
       return;
     }
-    if (rubric.some((r) => r.max_val <= 0)) {
+
+    const normalizedNames = normalizedRubric.map((r) =>
+      r.name.toLowerCase(),
+    );
+    if (new Set(normalizedNames).size !== normalizedNames.length) {
+      setError("Criteria names must be unique.");
+      return;
+    }
+
+    if (normalizedRubric.some((r) => r.max_val <= 0)) {
       setError("Max score must be greater than 0.");
+      return;
+    }
+
+    if (normalizedRubric.some((r) => r.max_val > MAX_RUBRIC_SCORE)) {
+      setError("Max score must be less than or equal to 1,000,000,000,000.");
       return;
     }
 
@@ -64,7 +89,7 @@ export function RubricSettingsForm({
       const res = await fetch(`/api/org/${orgId}/openings/${openingId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ rubric }),
+        body: JSON.stringify({ rubric: normalizedRubric }),
       });
 
       if (!res.ok) {
@@ -109,6 +134,7 @@ export function RubricSettingsForm({
                 <Input
                   type="number"
                   min="1"
+                  max={MAX_RUBRIC_SCORE}
                   value={item.max_val}
                   onChange={(e) =>
                     handleUpdate(index, "max_val", e.target.value)

--- a/app/protected/org/[orgId]/opening/[openingId]/rubric/components/RubricSettingsForm.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/rubric/components/RubricSettingsForm.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Loading01 } from "@untitled-ui/icons-react";
+import { Loading01, Trash01 } from "@untitled-ui/icons-react";
 
 interface Rubric {
   name: string;
@@ -109,7 +109,7 @@ export function RubricSettingsForm({
       <Card>
         <CardContent className="p-6">
           {/* Header row */}
-          <div className="grid grid-cols-[1fr_120px_1fr] gap-4 mb-4">
+          <div className="grid grid-cols-[1fr_120px_1fr_32px] gap-4 mb-4">
             <span className="text-sm font-semibold">
               Criteria<span className="text-red-500">*</span>
             </span>
@@ -117,6 +117,7 @@ export function RubricSettingsForm({
               Max Score<span className="text-red-500">*</span>
             </span>
             <span className="text-sm font-semibold">Description</span>
+            <span />
           </div>
 
           {/* Rubric rows */}
@@ -124,7 +125,7 @@ export function RubricSettingsForm({
             {rubric.map((item, index) => (
               <div
                 key={index}
-                className="grid grid-cols-[1fr_120px_1fr] gap-4 items-center"
+                className="grid grid-cols-[1fr_120px_1fr_32px] gap-4 items-center"
               >
                 <Input
                   value={item.name}
@@ -147,6 +148,15 @@ export function RubricSettingsForm({
                   }
                   placeholder=""
                 />
+                <button
+                  type="button"
+                  onClick={() =>
+                    setRubric(rubric.filter((_, i) => i !== index))
+                  }
+                  className="text-gray-300 hover:text-red-400 transition-colors"
+                >
+                  <Trash01 className="h-4 w-4" />
+                </button>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Changes:
- Renamed rubric toggle from Hide to Delete and made delete fully reset rubric state (not just hide UI).

- Added rubric validation on new opening form and standalone rubric page:
  - criterion name required (when rubric is used)
  - criterion names must be unique (case-insensitive)
  - max_val upper bound set to 1,000,000,000,000
- Fixed max score UI input so users can backspace to empty while editing (no more prefix 0); normalization/validation now happens on save.
- Added ability to remove rubric item on the "edit rubric" standalone page
<img width="1074" height="427" alt="Screenshot 2026-03-07 at 3 53 10 PM" src="https://github.com/user-attachments/assets/0479023e-e9ad-498a-870c-c047241bcb36" />
<img width="1216" height="388" alt="Screenshot 2026-03-07 at 3 53 32 PM" src="https://github.com/user-attachments/assets/3b44466b-fcb1-4573-845a-4618c2fb95f0" />
