### PR TITLE
Add native form builder (replaces CSV-from-Google-Forms)

### DIFF
--- a/app/api/openings/[openingId]/apply/route.ts
+++ b/app/api/openings/[openingId]/apply/route.ts
@@ -100,12 +100,15 @@ export async function POST(request: Request, { params }: { params: Params }) {
     ...formResponses,
   };
 
-  const { error: insertError } = await supabase.from("applications").insert({
-    opening_id: openingId,
-    applicant_id: applicant.id,
-    form_responses: enrichedResponses,
-    status: "Applied",
-  });
+  const { error: insertError } = await supabase.from("applications").upsert(
+    {
+      opening_id: openingId,
+      applicant_id: applicant.id,
+      form_responses: enrichedResponses,
+      status: "Applied",
+    },
+    { onConflict: "opening_id, applicant_id", ignoreDuplicates: true },
+  );
 
   if (insertError) {
     return NextResponse.json({ error: insertError.message }, { status: 500 });

--- a/app/api/openings/[openingId]/apply/route.ts
+++ b/app/api/openings/[openingId]/apply/route.ts
@@ -1,0 +1,115 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { ensureApplicant } from "@/lib/csv-upload-utils";
+import { parseQuestionText } from "@/lib/question-utils";
+
+type Params = Promise<{ openingId: string }>;
+
+export async function POST(request: Request, { params }: { params: Params }) {
+  const { openingId } = await params;
+  const supabase = await createClient();
+
+  // Auth required
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const email = user.email ?? "";
+  if (!email.endsWith("@rice.edu")) {
+    return NextResponse.json(
+      { error: "A Rice University email (@rice.edu) is required to apply." },
+      { status: 400 },
+    );
+  }
+
+  const netId = email.split("@")[0];
+  const name: string =
+    (user.user_metadata?.full_name as string | undefined) || netId;
+
+  // Verify opening is accepting applications
+  const { data: opening, error: openingError } = await supabase
+    .from("openings")
+    .select("id, status")
+    .eq("id", openingId)
+    .single();
+
+  if (openingError || !opening) {
+    return NextResponse.json({ error: "Opening not found" }, { status: 404 });
+  }
+
+  if (opening.status !== "open") {
+    return NextResponse.json(
+      { error: "This opening is not currently accepting applications." },
+      { status: 409 },
+    );
+  }
+
+  // Find or create applicant record
+  const applicant = await ensureApplicant(supabase, netId, name);
+
+  // Duplicate check
+  const { data: existing } = await supabase
+    .from("applications")
+    .select("id")
+    .eq("opening_id", openingId)
+    .eq("applicant_id", applicant.id)
+    .maybeSingle();
+
+  if (existing) {
+    return NextResponse.json(
+      { error: "You have already submitted an application for this opening." },
+      { status: 409 },
+    );
+  }
+
+  // Validate required questions
+  const body = await request.json();
+  const formResponses: Record<string, string | string[]> =
+    body.form_responses ?? {};
+
+  const { data: questions } = await supabase
+    .from("questions")
+    .select("question_text, is_required")
+    .eq("opening_id", openingId);
+
+  for (const q of questions ?? []) {
+    if (!q.is_required) continue;
+    const { label } = parseQuestionText(q.question_text);
+    const answer = formResponses[label];
+    const isEmpty =
+      answer === undefined ||
+      answer === null ||
+      answer === "" ||
+      (Array.isArray(answer) && answer.length === 0);
+    if (isEmpty) {
+      return NextResponse.json(
+        { error: `Required field is missing: ${label}` },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Insert application — always include name and netid in form_responses
+  const enrichedResponses = {
+    name,
+    netid: netId,
+    ...formResponses,
+  };
+
+  const { error: insertError } = await supabase.from("applications").insert({
+    opening_id: openingId,
+    applicant_id: applicant.id,
+    form_responses: enrichedResponses,
+    status: "Applied",
+  });
+
+  if (insertError) {
+    return NextResponse.json({ error: insertError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true }, { status: 201 });
+}

--- a/app/api/openings/[openingId]/route.ts
+++ b/app/api/openings/[openingId]/route.ts
@@ -1,0 +1,28 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+type Params = Promise<{ openingId: string }>;
+
+/** Public endpoint — returns opening metadata + questions for the apply page. */
+export async function GET(_request: Request, { params }: { params: Params }) {
+  const { openingId } = await params;
+  const supabase = await createClient();
+
+  const { data: opening, error: openingError } = await supabase
+    .from("openings")
+    .select("id, title, description, status, closes_at, orgs(name)")
+    .eq("id", openingId)
+    .single();
+
+  if (openingError || !opening) {
+    return NextResponse.json({ error: "Opening not found" }, { status: 404 });
+  }
+
+  const { data: questions } = await supabase
+    .from("questions")
+    .select("id, question_text, is_required, sort_order")
+    .eq("opening_id", openingId)
+    .order("sort_order", { ascending: true });
+
+  return NextResponse.json({ opening, questions: questions ?? [] });
+}

--- a/app/api/org/[orgId]/members/[userId]/route.ts
+++ b/app/api/org/[orgId]/members/[userId]/route.ts
@@ -1,27 +1,95 @@
 import { createClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 
+type Params = Promise<{ orgId: string; userId: string }>;
+
+/**
+ * Shared helper: authenticate the caller, look up their role in the org,
+ * and count total admins. Returns everything the handlers need to authorise.
+ */
+async function getAuthContext(orgId: string) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { supabase, error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+
+  // Caller's membership
+  const { data: callerMembership } = await supabase
+    .from("org_members")
+    .select("role")
+    .eq("user_id", user.id)
+    .eq("org_id", orgId)
+    .single();
+
+  // Count admins in the org
+  const { count: adminCount } = await supabase
+    .from("org_members")
+    .select("id", { count: "exact", head: true })
+    .eq("org_id", orgId)
+    .eq("role", "admin");
+
+  return {
+    supabase,
+    callerId: user.id,
+    callerRole: callerMembership?.role as "admin" | "reviewer" | null,
+    adminCount: adminCount ?? 0,
+    error: null,
+  };
+}
+
 export async function PUT(
   request: Request,
-  { params }: { params: Promise<{ orgId: string; userId: string }> },
+  { params }: { params: Params },
 ) {
   try {
     const { orgId, userId } = await params;
     const body = await request.json();
     const { role } = body;
 
-    if (!role) {
+    if (!role || !["admin", "reviewer"].includes(role)) {
       return NextResponse.json(
-        { error: "Missing required fields" },
+        { error: "Invalid or missing role" },
         { status: 400 },
       );
     }
 
-    const supabase = await createClient();
+    const ctx = await getAuthContext(orgId);
+    if (ctx.error) return ctx.error;
 
-    const { error } = await supabase
+    // Only admins can change roles
+    if (ctx.callerRole !== "admin") {
+      return NextResponse.json(
+        { error: "Only admins can change member roles" },
+        { status: 403 },
+      );
+    }
+
+    // Prevent demoting the last admin
+    if (role === "reviewer") {
+      const { data: targetMembership } = await ctx.supabase
+        .from("org_members")
+        .select("role")
+        .eq("user_id", userId)
+        .eq("org_id", orgId)
+        .single();
+
+      if (targetMembership?.role === "admin" && ctx.adminCount <= 1) {
+        return NextResponse.json(
+          { error: "Cannot demote the only admin. Transfer admin role first." },
+          { status: 403 },
+        );
+      }
+    }
+
+    const { error } = await ctx.supabase
       .from("org_members")
-      .update({ role: role })
+      .update({ role })
       .eq("org_id", orgId)
       .eq("user_id", userId);
 
@@ -40,14 +108,50 @@ export async function PUT(
 
 export async function DELETE(
   request: Request,
-  { params }: { params: Promise<{ orgId: string; userId: string }> },
+  { params }: { params: Params },
 ) {
   try {
     const { orgId, userId } = await params;
 
-    const supabase = await createClient();
+    const ctx = await getAuthContext(orgId);
+    if (ctx.error) return ctx.error;
 
-    const { error } = await supabase
+    const isSelf = ctx.callerId === userId;
+
+    if (isSelf) {
+      // Leaving the org — block if they're the only admin
+      if (ctx.callerRole === "admin" && ctx.adminCount <= 1) {
+        return NextResponse.json(
+          { error: "Cannot leave as the only admin. Transfer admin role first." },
+          { status: 403 },
+        );
+      }
+    } else {
+      // Removing someone else — must be an admin
+      if (ctx.callerRole !== "admin") {
+        return NextResponse.json(
+          { error: "Only admins can remove members" },
+          { status: 403 },
+        );
+      }
+
+      // Prevent removing the last admin
+      const { data: targetMembership } = await ctx.supabase
+        .from("org_members")
+        .select("role")
+        .eq("user_id", userId)
+        .eq("org_id", orgId)
+        .single();
+
+      if (targetMembership?.role === "admin" && ctx.adminCount <= 1) {
+        return NextResponse.json(
+          { error: "Cannot remove the only admin" },
+          { status: 403 },
+        );
+      }
+    }
+
+    const { error } = await ctx.supabase
       .from("org_members")
       .delete()
       .eq("org_id", orgId)

--- a/app/api/org/[orgId]/members/route.ts
+++ b/app/api/org/[orgId]/members/route.ts
@@ -46,17 +46,41 @@ export async function POST(
 ) {
   try {
     const { orgId } = await params;
-    const body = await request.json();
-    const { userId, role } = body;
+    const supabase = await createClient();
 
-    if (!userId || !role) {
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Only admins can add members
+    const { data: callerMembership } = await supabase
+      .from("org_members")
+      .select("role")
+      .eq("user_id", user.id)
+      .eq("org_id", orgId)
+      .single();
+
+    if (callerMembership?.role !== "admin") {
       return NextResponse.json(
-        { error: "Missing required fields" },
-        { status: 400 },
+        { error: "Only admins can add members" },
+        { status: 403 },
       );
     }
 
-    const supabase = await createClient();
+    const body = await request.json();
+    const { userId, role } = body;
+
+    if (!userId || !role || !["admin", "reviewer"].includes(role)) {
+      return NextResponse.json(
+        { error: "Missing or invalid fields" },
+        { status: 400 },
+      );
+    }
 
     const { data, error } = await supabase
       .from("org_members")

--- a/app/api/org/[orgId]/opening/[openingId]/questions/route.ts
+++ b/app/api/org/[orgId]/opening/[openingId]/questions/route.ts
@@ -75,31 +75,17 @@ export async function PATCH(request: Request, { params }: { params: Params }) {
     );
   }
 
-  // Delete existing and reinsert — same pattern as CSV upload
-  const { error: deleteError } = await supabase
-    .from("questions")
-    .delete()
-    .eq("opening_id", openingId);
-
-  if (deleteError) {
-    return NextResponse.json({ error: deleteError.message }, { status: 500 });
-  }
-
-  if (questions.length === 0) {
-    return NextResponse.json({ questions: [] });
-  }
-
+  // Atomically delete existing and insert new questions
   const records = questions.map((q, i) => ({
-    opening_id: openingId,
     question_text: q.question_text,
     is_required: q.is_required ?? null,
     sort_order: i,
   }));
 
-  const { data, error } = await supabase
-    .from("questions")
-    .insert(records)
-    .select();
+  const { data, error } = await supabase.rpc("replace_opening_questions", {
+    target_opening_id: openingId,
+    questions_json: records,
+  });
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/app/api/org/[orgId]/opening/[openingId]/questions/route.ts
+++ b/app/api/org/[orgId]/opening/[openingId]/questions/route.ts
@@ -60,6 +60,21 @@ export async function PATCH(request: Request, { params }: { params: Params }) {
     );
   }
 
+  // Verify the opening belongs to this org before touching its questions
+  const { data: opening, error: openingError } = await supabase
+    .from("openings")
+    .select("id")
+    .eq("id", openingId)
+    .eq("org_id", orgId)
+    .single();
+
+  if (openingError || !opening) {
+    return NextResponse.json(
+      { error: "Opening not found in this organization" },
+      { status: 404 },
+    );
+  }
+
   // Delete existing and reinsert — same pattern as CSV upload
   const { error: deleteError } = await supabase
     .from("questions")

--- a/app/api/org/[orgId]/opening/[openingId]/questions/route.ts
+++ b/app/api/org/[orgId]/opening/[openingId]/questions/route.ts
@@ -1,0 +1,94 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+type Params = Promise<{ orgId: string; openingId: string }>;
+
+export async function GET(_request: Request, { params }: { params: Params }) {
+  const { openingId } = await params;
+  const supabase = await createClient();
+
+  const { data, error } = await supabase
+    .from("questions")
+    .select("*")
+    .eq("opening_id", openingId)
+    .order("sort_order", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ questions: data });
+}
+
+export async function PATCH(request: Request, { params }: { params: Params }) {
+  const { orgId, openingId } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: membership } = await supabase
+    .from("org_members")
+    .select("role")
+    .eq("user_id", user.id)
+    .eq("org_id", orgId)
+    .single();
+
+  if (membership?.role !== "admin") {
+    return NextResponse.json(
+      { error: "Only admins can manage questions" },
+      { status: 403 },
+    );
+  }
+
+  const body = await request.json();
+  const questions: Array<{
+    question_text: string;
+    is_required: boolean | null;
+    sort_order: number;
+  }> = body.questions;
+
+  if (!Array.isArray(questions)) {
+    return NextResponse.json(
+      { error: "questions must be an array" },
+      { status: 400 },
+    );
+  }
+
+  // Delete existing and reinsert — same pattern as CSV upload
+  const { error: deleteError } = await supabase
+    .from("questions")
+    .delete()
+    .eq("opening_id", openingId);
+
+  if (deleteError) {
+    return NextResponse.json({ error: deleteError.message }, { status: 500 });
+  }
+
+  if (questions.length === 0) {
+    return NextResponse.json({ questions: [] });
+  }
+
+  const records = questions.map((q, i) => ({
+    opening_id: openingId,
+    question_text: q.question_text,
+    is_required: q.is_required ?? null,
+    sort_order: i,
+  }));
+
+  const { data, error } = await supabase
+    .from("questions")
+    .insert(records)
+    .select();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ questions: data });
+}

--- a/app/api/orgs/route.ts
+++ b/app/api/orgs/route.ts
@@ -23,32 +23,21 @@ export async function POST(request: Request) {
       );
     }
 
-    // Create the organization
-    const { data: newOrg, error: insertError } = await supabase
-      .from("orgs")
-      .insert({
-        name: name.trim(),
-        description: description?.trim() || null,
-      })
-      .select("id")
-      .single();
+    // Atomically create org and assign creator as admin
+    const { data: newOrgId, error: rpcError } = await supabase.rpc(
+      "create_org_with_admin",
+      {
+        org_name: name.trim(),
+        org_description: description?.trim() || null,
+        creator_id: user.id,
+      },
+    );
 
-    if (insertError) {
-      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    if (rpcError) {
+      return NextResponse.json({ error: rpcError.message }, { status: 500 });
     }
 
-    // Add the creator as an admin of the organization
-    const { error: memberError } = await supabase.from("org_members").insert({
-      user_id: user.id,
-      org_id: newOrg.id,
-      role: "admin",
-    });
-
-    if (memberError) {
-      return NextResponse.json({ error: memberError.message }, { status: 500 });
-    }
-
-    return NextResponse.json({ id: newOrg.id }, { status: 201 });
+    return NextResponse.json({ id: newOrgId }, { status: 201 });
   } catch (error) {
     console.error("Error creating organization:", error);
     return NextResponse.json(

--- a/app/apply/[openingId]/ApplyForm.tsx
+++ b/app/apply/[openingId]/ApplyForm.tsx
@@ -24,6 +24,7 @@ interface ApplyFormProps {
   questions: RawQuestion[];
   isAuthenticated: boolean;
   userEmail: string | null;
+  alreadyApplied: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,6 +192,7 @@ export function ApplyForm({
   questions,
   isAuthenticated,
   userEmail,
+  alreadyApplied,
 }: ApplyFormProps) {
   const parsedQuestions = questions.map((q) => ({
     ...q,
@@ -296,6 +298,30 @@ export function ApplyForm({
           <p className="text-sm text-yellow-800">
             A Rice University email address (<strong>@rice.edu</strong>) is
             required to apply. You are signed in as <strong>{userEmail}</strong>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Already submitted
+  if (alreadyApplied) {
+    return (
+      <div>
+        {header}
+        <div className="rounded-xl border border-blue-200 bg-blue-50 p-8 text-center space-y-2">
+          <p className="text-sm text-blue-800 font-medium">
+            You&apos;ve already applied to this opening.
+          </p>
+          <p className="text-sm text-blue-700">
+            Track your status on your{" "}
+            <a
+              href="/protected/applications"
+              className="underline hover:text-blue-900"
+            >
+              applications page
+            </a>
             .
           </p>
         </div>

--- a/app/apply/[openingId]/ApplyForm.tsx
+++ b/app/apply/[openingId]/ApplyForm.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import Script from "next/script";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { parseQuestionText } from "@/lib/question-utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface RawQuestion {
+  id: string;
+  question_text: string;
+  is_required: boolean | null;
+  sort_order: number | null;
+}
+
+interface ApplyFormProps {
+  openingId: string;
+  title: string;
+  description: string;
+  orgName: string;
+  closesAt: string | null;
+  questions: RawQuestion[];
+  isAuthenticated: boolean;
+  userEmail: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Google sign-in button (re-fresh page after sign-in)
+// ---------------------------------------------------------------------------
+
+function SignInForApplyBtn() {
+  const router = useRouter();
+
+  const handleSignIn = useCallback(
+    async (response: { credential: string }) => {
+      const supabase = createClient();
+      const { data } = await supabase.auth.signInWithIdToken({
+        provider: "google",
+        token: response.credential,
+      });
+      if (data?.user) {
+        router.refresh();
+      }
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    (
+      window as unknown as {
+        handleApplySignIn: (r: { credential: string }) => Promise<void>;
+      }
+    ).handleApplySignIn = handleSignIn;
+  }, [handleSignIn]);
+
+  return (
+    <>
+      <Script
+        src="https://accounts.google.com/gsi/client"
+        strategy="afterInteractive"
+      />
+      <div
+        id="g_id_onload"
+        data-client_id="530339823745-p2p8i1r4e6ki8f1ra93aar28n5pil04f.apps.googleusercontent.com"
+        data-context="signin"
+        data-ux_mode="popup"
+        data-callback="handleApplySignIn"
+        data-auto_prompt="false"
+      />
+      <div
+        className="g_id_signin"
+        data-type="standard"
+        data-shape="rectangular"
+        data-theme="filled_white"
+        data-text="continue_with"
+        data-size="large"
+        data-logo_alignment="left"
+      />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field renderer
+// ---------------------------------------------------------------------------
+
+function FormField({
+  question,
+  value,
+  onChange,
+}: {
+  question: {
+    label: string;
+    type: string;
+    options: string[] | null;
+    is_required: boolean | null;
+  };
+  value: string | string[];
+  onChange: (v: string | string[]) => void;
+}) {
+  const baseClass =
+    "w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-owl-purple/40";
+
+  switch (question.type) {
+    case "textarea":
+      return (
+        <textarea
+          className={`${baseClass} min-h-[100px] resize-y`}
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          required={question.is_required ?? false}
+        />
+      );
+    case "select":
+      return (
+        <select
+          className={baseClass}
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          required={question.is_required ?? false}
+        >
+          <option value="">Select an option…</option>
+          {(question.options ?? []).map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      );
+    case "checkbox":
+      return (
+        <div className="space-y-1.5">
+          {(question.options ?? []).map((opt) => {
+            const checked = Array.isArray(value) && value.includes(opt);
+            return (
+              <label
+                key={opt}
+                className="flex items-center gap-2 text-sm cursor-pointer"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => {
+                    const arr = Array.isArray(value) ? [...value] : [];
+                    onChange(
+                      checked ? arr.filter((v) => v !== opt) : [...arr, opt],
+                    );
+                  }}
+                  className="w-4 h-4"
+                />
+                {opt}
+              </label>
+            );
+          })}
+        </div>
+      );
+    case "url":
+      return (
+        <Input
+          type="url"
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          required={question.is_required ?? false}
+          placeholder="https://"
+        />
+      );
+    default:
+      return (
+        <Input
+          type="text"
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => onChange(e.target.value)}
+          required={question.is_required ?? false}
+        />
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function ApplyForm({
+  openingId,
+  title,
+  description,
+  orgName,
+  closesAt,
+  questions,
+  isAuthenticated,
+  userEmail,
+}: ApplyFormProps) {
+  const parsedQuestions = questions.map((q) => ({
+    ...q,
+    ...parseQuestionText(q.question_text),
+  }));
+
+  const [formState, setFormState] = useState<Record<string, string | string[]>>(
+    () =>
+      Object.fromEntries(
+        parsedQuestions.map((q) => [q.label, q.type === "checkbox" ? [] : ""]),
+      ),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/openings/${openingId}/apply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ form_responses: formState }),
+      });
+
+      if (res.ok) {
+        setSubmitted(true);
+      } else {
+        const json = await res.json();
+        setError(json.error ?? "Something went wrong. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Header shared between states
+  const header = (
+    <div className="mb-8">
+      <p className="text-sm text-gray-500 mb-1">{orgName}</p>
+      <h1 className="text-2xl font-bold text-gray-900">{title}</h1>
+      {description && (
+        <p className="text-gray-600 mt-2 text-sm leading-relaxed">
+          {description}
+        </p>
+      )}
+      {closesAt && (
+        <p className="text-xs text-gray-400 mt-2">
+          Closes {new Date(closesAt).toLocaleDateString()}
+        </p>
+      )}
+    </div>
+  );
+
+  if (submitted) {
+    return (
+      <div>
+        {header}
+        <div className="rounded-xl border border-green-200 bg-green-50 p-8 text-center space-y-2">
+          <p className="text-lg font-semibold text-green-800">
+            Application submitted!
+          </p>
+          <p className="text-sm text-green-700">
+            You can track your application status on your{" "}
+            <a
+              href="/protected/applications"
+              className="underline hover:text-green-900"
+            >
+              applications page
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div>
+        {header}
+        <div className="rounded-xl border border-gray-200 bg-white p-8 text-center space-y-4">
+          <p className="text-sm text-gray-600">
+            Sign in with your Rice Google account to apply.
+          </p>
+          <div className="flex justify-center">
+            <SignInForApplyBtn />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Not a rice.edu email
+  if (userEmail && !userEmail.endsWith("@rice.edu")) {
+    return (
+      <div>
+        {header}
+        <div className="rounded-xl border border-yellow-200 bg-yellow-50 p-8 text-center space-y-2">
+          <p className="text-sm text-yellow-800">
+            A Rice University email address (<strong>@rice.edu</strong>) is
+            required to apply. You are signed in as <strong>{userEmail}</strong>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {header}
+
+      {parsedQuestions.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-8 text-center text-sm text-gray-500">
+          No questions have been added to this form yet.
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-6 bg-white rounded-xl border border-gray-200 p-6"
+        >
+          {parsedQuestions.map((q) => (
+            <div key={q.id} className="space-y-1.5">
+              <label className="block text-sm font-medium text-gray-800">
+                {q.label}
+                {q.is_required && (
+                  <span className="text-red-500 ml-0.5">*</span>
+                )}
+              </label>
+              <FormField
+                question={q}
+                value={formState[q.label] ?? (q.type === "checkbox" ? [] : "")}
+                onChange={(v) =>
+                  setFormState((prev) => ({ ...prev, [q.label]: v }))
+                }
+              />
+            </div>
+          ))}
+
+          {error && (
+            <p className="text-sm text-red-600 rounded-lg bg-red-50 px-4 py-3">
+              {error}
+            </p>
+          )}
+
+          <Button type="submit" disabled={submitting} className="w-full">
+            {submitting ? "Submitting…" : "Submit Application"}
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/app/apply/[openingId]/page.tsx
+++ b/app/apply/[openingId]/page.tsx
@@ -1,0 +1,65 @@
+import { createClient } from "@/lib/supabase/server";
+import { ApplyForm } from "./ApplyForm";
+
+interface Props {
+  params: Promise<{ openingId: string }>;
+}
+
+export default async function ApplyPage({ params }: Props) {
+  const { openingId } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const { data: opening, error } = await supabase
+    .from("openings")
+    .select("id, title, description, status, closes_at, orgs(name)")
+    .eq("id", openingId)
+    .single();
+
+  if (error || !opening) {
+    return (
+      <div className="text-center py-16 text-gray-500">
+        <p className="text-lg font-medium">Opening not found.</p>
+      </div>
+    );
+  }
+
+  if (opening.status !== "open") {
+    return (
+      <div className="text-center py-16 text-gray-500">
+        <p className="text-lg font-medium">
+          This opening is not currently accepting applications.
+        </p>
+      </div>
+    );
+  }
+
+  const { data: questions } = await supabase
+    .from("questions")
+    .select("id, question_text, is_required, sort_order")
+    .eq("opening_id", openingId)
+    .order("sort_order", { ascending: true });
+
+  const orgName =
+    opening.orgs && !Array.isArray(opening.orgs)
+      ? (opening.orgs as { name: string }).name
+      : Array.isArray(opening.orgs) && opening.orgs.length > 0
+        ? (opening.orgs[0] as { name: string }).name
+        : "Unknown Org";
+
+  return (
+    <ApplyForm
+      openingId={openingId}
+      title={opening.title}
+      description={opening.description ?? ""}
+      orgName={orgName}
+      closesAt={opening.closes_at}
+      questions={questions ?? []}
+      isAuthenticated={!!user}
+      userEmail={user?.email ?? null}
+    />
+  );
+}

--- a/app/apply/[openingId]/page.tsx
+++ b/app/apply/[openingId]/page.tsx
@@ -15,7 +15,9 @@ export default async function ApplyPage({ params }: Props) {
 
   const { data: opening, error } = await supabase
     .from("openings")
-    .select("id, title, description, status, closes_at, orgs(name)")
+    .select(
+      "id, title, description, status, closes_at, org_id, orgs!org_id(name)",
+    )
     .eq("id", openingId)
     .single();
 
@@ -43,12 +45,29 @@ export default async function ApplyPage({ params }: Props) {
     .eq("opening_id", openingId)
     .order("sort_order", { ascending: true });
 
-  const orgName =
-    opening.orgs && !Array.isArray(opening.orgs)
-      ? (opening.orgs as { name: string }).name
-      : Array.isArray(opening.orgs) && opening.orgs.length > 0
-        ? (opening.orgs[0] as { name: string }).name
-        : "Unknown Org";
+  const orgRow = Array.isArray(opening.orgs) ? opening.orgs[0] : opening.orgs;
+  const orgName = (orgRow as { name: string } | null)?.name ?? "Unknown Org";
+
+  // Check if the authenticated user has already applied
+  let alreadyApplied = false;
+  if (user?.email?.endsWith("@rice.edu")) {
+    const netId = user.email.split("@")[0];
+    const { data: applicant } = await supabase
+      .from("applicants")
+      .select("id")
+      .eq("net_id", netId)
+      .maybeSingle();
+
+    if (applicant) {
+      const { data: existing } = await supabase
+        .from("applications")
+        .select("id")
+        .eq("opening_id", openingId)
+        .eq("applicant_id", applicant.id)
+        .maybeSingle();
+      alreadyApplied = !!existing;
+    }
+  }
 
   return (
     <ApplyForm
@@ -60,6 +79,7 @@ export default async function ApplyPage({ params }: Props) {
       questions={questions ?? []}
       isAuthenticated={!!user}
       userEmail={user?.email ?? null}
+      alreadyApplied={alreadyApplied}
     />
   );
 }

--- a/app/apply/layout.tsx
+++ b/app/apply/layout.tsx
@@ -1,0 +1,11 @@
+export default function ApplyLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col items-center py-12 px-4">
+      <div className="w-full max-w-2xl">{children}</div>
+    </div>
+  );
+}

--- a/app/protected/org/[orgId]/new-opening/page.tsx
+++ b/app/protected/org/[orgId]/new-opening/page.tsx
@@ -57,16 +57,16 @@ export default function NewOpeningPage() {
   React.useEffect(() => {
     const fetchData = async () => {
       try {
-        const [orgsRes, reviewersRes] = await Promise.all([
-          fetch(`/api/orgs`),
+        const [orgStatusRes, reviewersRes] = await Promise.all([
+          fetch(`/api/user/org-status`),
           fetch(`/api/org/${orgId}/members?role=admin,reviewer`),
         ]);
-        if (orgsRes.ok) {
-          const orgs = await orgsRes.json();
-          const org = orgs.find(
-            (o: { id: string; name: string }) => o.id === orgId,
+        if (orgStatusRes.ok) {
+          const { memberships } = await orgStatusRes.json();
+          const membership = memberships?.find(
+            (m: { org_id: string; org_name: string }) => m.org_id === orgId,
           );
-          if (org) setOrgName(org.name);
+          if (membership) setOrgName(membership.org_name);
         }
         if (reviewersRes.ok) {
           const reviewerData = await reviewersRes.json();

--- a/app/protected/org/[orgId]/new-opening/page.tsx
+++ b/app/protected/org/[orgId]/new-opening/page.tsx
@@ -156,24 +156,63 @@ export default function NewOpeningPage() {
           />
         </div>
 
-        {/* Application Link */}
-        <div className="space-y-2">
-          <Label
-            htmlFor="application_link"
-            className="text-sm font-medium text-gray-700"
-          >
-            Application Link
+        {/* Application Method */}
+        <div className="space-y-3">
+          <Label className="text-sm font-medium text-gray-700">
+            Application Method
           </Label>
-          <Input
-            id="application_link"
-            type="url"
-            value={formData.application_link}
-            onChange={(e) =>
-              setFormData({ ...formData, application_link: e.target.value })
-            }
-            placeholder="https://forms.google.com/..."
-            className="h-11 text-sm w-full"
-          />
+          <div className="flex rounded-lg border border-gray-200 w-fit overflow-hidden">
+            <button
+              type="button"
+              onClick={() =>
+                setFormData({ ...formData, application_link: "" })
+              }
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                !formData.application_link
+                  ? "bg-owl-purple text-white"
+                  : "bg-white text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              Native Form
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setFormData({
+                  ...formData,
+                  application_link:
+                    formData.application_link || "https://",
+                })
+              }
+              className={`px-4 py-2 text-sm font-medium transition-colors border-l border-gray-200 ${
+                formData.application_link
+                  ? "bg-owl-purple text-white"
+                  : "bg-white text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              Google Forms
+            </button>
+          </div>
+          {!formData.application_link ? (
+            <p className="text-xs text-gray-500">
+              Build a form in the Questions tab after creating this opening.
+              Applicants will fill it out at a shareable link.
+            </p>
+          ) : (
+            <Input
+              id="application_link"
+              type="url"
+              value={formData.application_link}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  application_link: e.target.value,
+                })
+              }
+              placeholder="https://forms.google.com/..."
+              className="h-11 text-sm w-full"
+            />
+          )}
         </div>
 
         {/* Description */}

--- a/app/protected/org/[orgId]/opening/[openingId]/applicant/[applicantId]/components/CommentsPanel.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/applicant/[applicantId]/components/CommentsPanel.tsx
@@ -32,7 +32,7 @@ export function CommentsPanel({
   const [comments, setComments] = useState<Comment[]>([]);
   const [newComment, setNewComment] = useState("");
   const [loading, setLoading] = useState(false);
-  const [isCommentsOpen, setIsCommentsOpen] = useState(false);
+  const [isCommentsOpen, setIsCommentsOpen] = useState(true);
 
   const fetchComments = useCallback(async () => {
     try {
@@ -118,8 +118,8 @@ export function CommentsPanel({
         type="single"
         collapsible
         className="w-full"
+        value={isCommentsOpen ? "item-1" : ""}
         onValueChange={(val) => setIsCommentsOpen(val === "item-1")}
-        defaultValue="item-1"
       >
         <AccordionItem value="item-1" className="border-none">
           <AccordionTrigger className="py-2 hover:no-underline font-semibold text-lg text-foreground">

--- a/app/protected/org/[orgId]/opening/[openingId]/components/OpeningTabs.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/components/OpeningTabs.tsx
@@ -3,19 +3,27 @@
 import { usePathname, useSearchParams } from "next/navigation";
 import { TabBar } from "@/components/tab-bar";
 
-const tabs = [
+const allTabs = [
   { id: "applicants", label: "Applicants" },
   { id: "questions", label: "Questions" },
   { id: "overview", label: "Overview" },
   { id: "upload", label: "Upload Data" },
 ] as const;
 
-type TabId = (typeof tabs)[number]["id"];
+type TabId = (typeof allTabs)[number]["id"];
 
-export function OpeningTabs() {
+interface OpeningTabsProps {
+  useNativeForm: boolean;
+}
+
+export function OpeningTabs({ useNativeForm }: OpeningTabsProps) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const currentTab = (searchParams.get("tab") as TabId) || "applicants";
+
+  const tabs = useNativeForm
+    ? allTabs.filter((t) => t.id !== "upload")
+    : allTabs;
 
   const buildHref = (tabId: string) => {
     const params = new URLSearchParams(searchParams.toString());

--- a/app/protected/org/[orgId]/opening/[openingId]/components/OverviewTab.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/components/OverviewTab.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/client";
 import type { ApplicationStatus } from "@/types/app";
 
@@ -28,6 +29,7 @@ interface OverviewTabProps {
   applicants: Applicant[];
   orgId: string;
   openingId: string;
+  openingStatus: string | null;
 }
 
 const STATUS_ORDER: ApplicationStatus[] = [
@@ -43,9 +45,15 @@ export function OverviewTab({
   applicants,
   orgId,
   openingId,
+  openingStatus,
 }: OverviewTabProps) {
   const [reviewers, setReviewers] = useState<Reviewer[]>([]);
   const [loadingReviewers, setLoadingReviewers] = useState(true);
+  const [origin, setOrigin] = useState("");
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
 
   useEffect(() => {
     async function fetchReviewers() {
@@ -181,6 +189,31 @@ export function OverviewTab({
           </CardContent>
         </Card>
       </div>
+
+      {/* Application Form Link */}
+      {openingStatus === "open" && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Application Form Link
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex items-center gap-2">
+            <code className="text-sm bg-muted px-2 py-1 rounded flex-1 truncate">
+              {origin}/apply/{openingId}
+            </code>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                navigator.clipboard.writeText(`${origin}/apply/${openingId}`)
+              }
+            >
+              Copy
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Rubric Settings */}
       <Link

--- a/app/protected/org/[orgId]/opening/[openingId]/components/OverviewTab.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/components/OverviewTab.tsx
@@ -30,6 +30,7 @@ interface OverviewTabProps {
   orgId: string;
   openingId: string;
   openingStatus: string | null;
+  applicationLink: string | null;
 }
 
 const STATUS_ORDER: ApplicationStatus[] = [
@@ -46,6 +47,7 @@ export function OverviewTab({
   orgId,
   openingId,
   openingStatus,
+  applicationLink,
 }: OverviewTabProps) {
   const [reviewers, setReviewers] = useState<Reviewer[]>([]);
   const [loadingReviewers, setLoadingReviewers] = useState(true);
@@ -199,18 +201,37 @@ export function OverviewTab({
             </CardTitle>
           </CardHeader>
           <CardContent className="flex items-center gap-2">
-            <code className="text-sm bg-muted px-2 py-1 rounded flex-1 truncate">
-              {origin}/apply/{openingId}
-            </code>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                navigator.clipboard.writeText(`${origin}/apply/${openingId}`)
-              }
-            >
-              Copy
-            </Button>
+            {applicationLink ? (
+              <>
+                <code className="text-sm bg-muted px-2 py-1 rounded flex-1 truncate">
+                  {applicationLink}
+                </code>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => navigator.clipboard.writeText(applicationLink)}
+                >
+                  Copy
+                </Button>
+              </>
+            ) : (
+              <>
+                <code className="text-sm bg-muted px-2 py-1 rounded flex-1 truncate">
+                  {origin}/apply/{openingId}
+                </code>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    navigator.clipboard.writeText(
+                      `${origin}/apply/${openingId}`,
+                    )
+                  }
+                >
+                  Copy
+                </Button>
+              </>
+            )}
           </CardContent>
         </Card>
       )}

--- a/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import {
   ChevronRight,
@@ -53,6 +54,7 @@ interface Application {
 interface QuestionsTabProps {
   openingId: string;
   orgId: string;
+  applicationLink: string | null;
 }
 
 const FIELD_TYPES: { value: FieldType; label: string }[] = [
@@ -202,16 +204,79 @@ function SortableQuestionCard({
 }
 
 // ---------------------------------------------------------------------------
+// Google Forms mode panel
+// ---------------------------------------------------------------------------
+
+function GoogleFormsMode({
+  applicationLink,
+  openingId,
+}: {
+  applicationLink: string;
+  openingId: string;
+}) {
+  const router = useRouter();
+  const [link, setLink] = useState(applicationLink);
+  const [saving, setSaving] = useState(false);
+
+  const saveLink = async () => {
+    setSaving(true);
+    try {
+      const supabase = createClient();
+      await supabase
+        .from("openings")
+        .update({ application_link: link })
+        .eq("id", openingId);
+      router.refresh();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="py-8 space-y-4">
+      <p className="text-sm text-gray-500">
+        Paste your Google Forms link below. Applicants will be directed to this
+        URL, and you can upload responses via the Upload Data tab.
+      </p>
+      <div className="flex gap-2 items-center max-w-xl">
+        <Input
+          value={link}
+          onChange={(e) => setLink(e.target.value)}
+          placeholder="https://docs.google.com/forms/..."
+          type="url"
+        />
+        <Button
+          size="sm"
+          onClick={saveLink}
+          disabled={saving || link === applicationLink}
+        >
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
-export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
+export function QuestionsTab({
+  openingId,
+  orgId,
+  applicationLink,
+}: QuestionsTabProps) {
+  const router = useRouter();
   const [questions, setQuestions] = useState<Question[]>([]);
   const [applications, setApplications] = useState<Application[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedQuestionId, setSelectedQuestionId] = useState<string | null>(
     null,
   );
+
+  // Mode: null/empty = native form, URL = Google Forms
+  const isNativeForm = !applicationLink;
+  const [switchingMode, setSwitchingMode] = useState(false);
 
   // Builder state
   const [isEditMode, setIsEditMode] = useState(false);
@@ -220,6 +285,22 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
   const [saveError, setSaveError] = useState<string | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor));
+
+  const toggleMode = async (toNative: boolean) => {
+    setSwitchingMode(true);
+    try {
+      const supabase = createClient();
+      const { error } = await supabase
+        .from("openings")
+        .update({
+          application_link: toNative ? null : "",
+        })
+        .eq("id", openingId);
+      if (!error) router.refresh();
+    } finally {
+      setSwitchingMode(false);
+    }
+  };
 
   useEffect(() => {
     const fetchData = async () => {
@@ -369,7 +450,40 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
     );
   }
 
-  // Edit mode
+  // Mode toggle bar (shared between edit & view)
+  const modeToggle = (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="text-gray-500">Mode:</span>
+      <div className="inline-flex rounded-lg border border-gray-200 overflow-hidden">
+        <button
+          type="button"
+          onClick={() => !isNativeForm && toggleMode(true)}
+          disabled={switchingMode}
+          className={`px-3 py-1.5 text-sm font-medium transition-colors ${
+            isNativeForm
+              ? "bg-owl-purple text-white"
+              : "bg-white text-gray-600 hover:bg-gray-50"
+          }`}
+        >
+          Native Form
+        </button>
+        <button
+          type="button"
+          onClick={() => isNativeForm && toggleMode(false)}
+          disabled={switchingMode}
+          className={`px-3 py-1.5 text-sm font-medium transition-colors ${
+            !isNativeForm
+              ? "bg-owl-purple text-white"
+              : "bg-white text-gray-600 hover:bg-gray-50"
+          }`}
+        >
+          Google Forms
+        </button>
+      </div>
+    </div>
+  );
+
+  // Edit mode (native form only)
   if (isEditMode) {
     return (
       <div className="py-4 space-y-4">
@@ -448,13 +562,21 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
   // View mode
   return (
     <div className="py-4 space-y-1">
-      <div className="flex justify-end mb-2">
-        <Button variant="outline" size="sm" onClick={enterEditMode}>
-          Edit Form
-        </Button>
+      <div className="flex items-center justify-between mb-2">
+        {modeToggle}
+        {isNativeForm && (
+          <Button variant="outline" size="sm" onClick={enterEditMode}>
+            Edit Form
+          </Button>
+        )}
       </div>
 
-      {questions.length === 0 ? (
+      {!isNativeForm ? (
+        <GoogleFormsMode
+          applicationLink={applicationLink ?? ""}
+          openingId={openingId}
+        />
+      ) : questions.length === 0 ? (
         <div className="py-12 text-center text-gray-500">
           <p>
             No questions configured. Click &ldquo;Edit Form&rdquo; to build your

--- a/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
@@ -2,13 +2,47 @@
 
 import { useState, useEffect } from "react";
 import { createClient } from "@/lib/supabase/client";
-import { ChevronRight } from "@untitled-ui/icons-react";
+import {
+  ChevronRight,
+  Plus,
+  Trash01,
+  GripVertical,
+} from "@untitled-ui/icons-react";
+import { parseQuestionText, encodeQuestionText } from "@/lib/question-utils";
+import type { FieldType } from "@/lib/question-utils";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 interface Question {
   id: string;
   question_text: string;
   is_required: boolean | null;
   sort_order: number | null;
+}
+
+interface DraftQuestion {
+  /** Temp id for new questions not yet saved, or DB id for existing ones */
+  tempId: string;
+  dbId: string | null;
+  label: string;
+  type: FieldType;
+  options: string[];
+  is_required: boolean;
 }
 
 interface Application {
@@ -18,9 +52,160 @@ interface Application {
 
 interface QuestionsTabProps {
   openingId: string;
+  orgId: string;
 }
 
-export function QuestionsTab({ openingId }: QuestionsTabProps) {
+const FIELD_TYPES: { value: FieldType; label: string }[] = [
+  { value: "text", label: "Short Answer" },
+  { value: "textarea", label: "Long Answer" },
+  { value: "select", label: "Dropdown" },
+  { value: "checkbox", label: "Checkboxes" },
+  { value: "url", label: "URL" },
+];
+
+// ---------------------------------------------------------------------------
+// Sortable question card
+// ---------------------------------------------------------------------------
+
+function SortableQuestionCard({
+  q,
+  index,
+  onChange,
+  onDelete,
+}: {
+  q: DraftQuestion;
+  index: number;
+  onChange: (updated: DraftQuestion) => void;
+  onDelete: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: q.tempId });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const needsOptions = q.type === "select" || q.type === "checkbox";
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="border border-gray-200 rounded-lg p-4 bg-white space-y-3"
+    >
+      <div className="flex items-start gap-2">
+        {/* Drag handle */}
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="mt-2 cursor-grab text-gray-400 hover:text-gray-600 shrink-0"
+          aria-label="Drag to reorder"
+        >
+          <GripVertical className="w-4 h-4" />
+        </button>
+
+        <div className="flex-1 space-y-2">
+          <div className="flex gap-2 items-center">
+            <span className="text-xs text-gray-400 shrink-0">Q{index + 1}</span>
+            <Input
+              value={q.label}
+              onChange={(e) => onChange({ ...q, label: e.target.value })}
+              placeholder="Question text"
+              className="flex-1"
+            />
+          </div>
+
+          <div className="flex gap-2 items-center flex-wrap">
+            <select
+              value={q.type}
+              onChange={(e) =>
+                onChange({
+                  ...q,
+                  type: e.target.value as FieldType,
+                  options: [],
+                })
+              }
+              className="text-sm border border-gray-200 rounded-md px-2 py-1.5 bg-white"
+            >
+              {FIELD_TYPES.map((ft) => (
+                <option key={ft.value} value={ft.value}>
+                  {ft.label}
+                </option>
+              ))}
+            </select>
+
+            <label className="flex items-center gap-1.5 text-sm text-gray-600 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={q.is_required}
+                onChange={(e) =>
+                  onChange({ ...q, is_required: e.target.checked })
+                }
+                className="w-3.5 h-3.5"
+              />
+              Required
+            </label>
+          </div>
+
+          {/* Options editor for select/checkbox */}
+          {needsOptions && (
+            <div className="space-y-1.5 pl-1">
+              {q.options.map((opt, oi) => (
+                <div key={oi} className="flex gap-1.5 items-center">
+                  <Input
+                    value={opt}
+                    onChange={(e) => {
+                      const next = [...q.options];
+                      next[oi] = e.target.value;
+                      onChange({ ...q, options: next });
+                    }}
+                    placeholder={`Option ${oi + 1}`}
+                    className="text-sm h-8"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const next = q.options.filter((_, i) => i !== oi);
+                      onChange({ ...q, options: next });
+                    }}
+                    className="text-gray-400 hover:text-red-500"
+                    aria-label="Remove option"
+                  >
+                    <Trash01 className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={() => onChange({ ...q, options: [...q.options, ""] })}
+                className="text-xs text-owl-purple hover:underline"
+              >
+                + Add option
+              </button>
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={onDelete}
+          className="mt-1 text-gray-400 hover:text-red-500 shrink-0"
+          aria-label="Delete question"
+        >
+          <Trash01 className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [applications, setApplications] = useState<Application[]>([]);
   const [loading, setLoading] = useState(true);
@@ -28,31 +213,32 @@ export function QuestionsTab({ openingId }: QuestionsTabProps) {
     null,
   );
 
+  // Builder state
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [draftQuestions, setDraftQuestions] = useState<DraftQuestion[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const sensors = useSensors(useSensor(PointerSensor));
+
   useEffect(() => {
     const fetchData = async () => {
       const supabase = createClient();
 
-      // Fetch questions
       const { data: questionsData, error: questionsError } = await supabase
         .from("questions")
         .select("*")
         .eq("opening_id", openingId)
         .order("sort_order", { ascending: true });
 
-      // Fetch applications with form responses
       const { data: applicationsData, error: applicationsError } =
         await supabase
           .from("applications")
           .select("id, form_responses")
           .eq("opening_id", openingId);
 
-      if (!questionsError && questionsData) {
-        setQuestions(questionsData);
-      }
-
-      if (!applicationsError && applicationsData) {
+      if (!questionsError && questionsData) setQuestions(questionsData);
+      if (!applicationsError && applicationsData)
         setApplications(applicationsData);
-      }
 
       setLoading(false);
     };
@@ -67,16 +253,102 @@ export function QuestionsTab({ openingId }: QuestionsTabProps) {
   };
 
   const getResponsesForQuestion = (questionText: string) => {
+    const { label } = parseQuestionText(questionText);
     return applications
       .map((app) => {
         const responses = app.form_responses || {};
-        return responses[questionText];
+        return responses[label];
       })
       .filter(
         (response) =>
           response !== undefined && response !== null && response !== "",
       );
   };
+
+  // ---------------------------------------------------------------------------
+  // Builder helpers
+  // ---------------------------------------------------------------------------
+
+  const enterEditMode = () => {
+    setDraftQuestions(
+      questions.map((q) => {
+        const parsed = parseQuestionText(q.question_text);
+        return {
+          tempId: q.id,
+          dbId: q.id,
+          label: parsed.label,
+          type: parsed.type,
+          options: parsed.options ?? [],
+          is_required: q.is_required ?? false,
+        };
+      }),
+    );
+    setIsEditMode(true);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setDraftQuestions((items) => {
+        const oldIndex = items.findIndex((i) => i.tempId === active.id);
+        const newIndex = items.findIndex((i) => i.tempId === over.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  };
+
+  const addQuestion = () => {
+    setDraftQuestions((prev) => [
+      ...prev,
+      {
+        tempId: crypto.randomUUID(),
+        dbId: null,
+        label: "",
+        type: "text",
+        options: [],
+        is_required: false,
+      },
+    ]);
+  };
+
+  const saveForm = async () => {
+    setSaving(true);
+    try {
+      const payload = draftQuestions.map((q) => ({
+        question_text: encodeQuestionText(
+          q.label,
+          q.type,
+          q.options.length > 0 ? q.options : null,
+        ),
+        is_required: q.is_required,
+      }));
+
+      const res = await fetch(
+        `/api/org/${orgId}/opening/${openingId}/questions`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ questions: payload }),
+        },
+      );
+
+      if (!res.ok) {
+        const json = await res.json();
+        alert(`Failed to save: ${json.error ?? "Unknown error"}`);
+        return;
+      }
+
+      const json = await res.json();
+      setQuestions(json.questions ?? []);
+      setIsEditMode(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
 
   if (loading) {
     return (
@@ -86,73 +358,141 @@ export function QuestionsTab({ openingId }: QuestionsTabProps) {
     );
   }
 
-  if (questions.length === 0) {
+  // Edit mode
+  if (isEditMode) {
     return (
-      <div className="py-12 text-center text-gray-500">
-        <p>No questions configured for this opening.</p>
+      <div className="py-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700">Edit Form</h2>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setIsEditMode(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" onClick={saveForm} disabled={saving}>
+              {saving ? "Saving…" : "Save Form"}
+            </Button>
+          </div>
+        </div>
+
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={draftQuestions.map((q) => q.tempId)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="space-y-2">
+              {draftQuestions.map((q, i) => (
+                <SortableQuestionCard
+                  key={q.tempId}
+                  q={q}
+                  index={i}
+                  onChange={(updated) =>
+                    setDraftQuestions((prev) =>
+                      prev.map((item) =>
+                        item.tempId === updated.tempId ? updated : item,
+                      ),
+                    )
+                  }
+                  onDelete={() =>
+                    setDraftQuestions((prev) =>
+                      prev.filter((item) => item.tempId !== q.tempId),
+                    )
+                  }
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={addQuestion}
+          className="w-full border-dashed"
+        >
+          <Plus className="w-4 h-4 mr-1" />
+          Add Question
+        </Button>
       </div>
     );
   }
 
+  // View mode
   return (
     <div className="py-4 space-y-1">
-      {questions.map((question, index) => {
-        const responses = getResponsesForQuestion(question.question_text);
-        const isExpanded = selectedQuestionId === question.id;
+      <div className="flex justify-end mb-2">
+        <Button variant="outline" size="sm" onClick={enterEditMode}>
+          Edit Form
+        </Button>
+      </div>
 
-        return (
-          <div key={question.id}>
-            <div
-              className="py-3 px-2 hover:bg-gray-50 transition-colors cursor-pointer rounded-sm border-b border-gray-100"
-              onClick={() => handleQuestionClick(question.id)}
-            >
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex-1">
-                  {/* Question counter */}
-                  <div className="text-xs text-gray-500 mb-1">
-                    Question {index + 1} of {questions.length}
-                  </div>
+      {questions.length === 0 ? (
+        <div className="py-12 text-center text-gray-500">
+          <p>
+            No questions configured. Click &ldquo;Edit Form&rdquo; to build your
+            form.
+          </p>
+        </div>
+      ) : (
+        questions.map((question, index) => {
+          const { label } = parseQuestionText(question.question_text);
+          const responses = getResponsesForQuestion(question.question_text);
+          const isExpanded = selectedQuestionId === question.id;
 
-                  {/* Question text */}
-                  <div className="flex items-center gap-2">
-                    <h2 className="text-base font-medium">
-                      {question.question_text}
-                    </h2>
-                    {question.is_required && (
-                      <span className="text-xs text-red-600">*</span>
-                    )}
-                  </div>
-                </div>
-
-                {/* Chevron icon */}
-                <ChevronRight
-                  className={`h-5 w-5 text-gray-400 shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`}
-                />
-              </div>
-            </div>
-
-            {/* Responses list */}
-            {isExpanded && (
-              <div className="py-3 px-4 bg-gray-50/50 space-y-3">
-                {responses.length > 0 ? (
-                  responses.map((response, idx) => (
-                    <div
-                      key={idx}
-                      className="py-3 px-4 bg-white/80 backdrop-blur-sm rounded-lg text-sm text-gray-800 shadow-sm hover:shadow-md transition-shadow"
-                    >
-                      {String(response)}
+          return (
+            <div key={question.id}>
+              <div
+                className="py-3 px-2 hover:bg-gray-50 transition-colors cursor-pointer rounded-sm border-b border-gray-100"
+                onClick={() => handleQuestionClick(question.id)}
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex-1">
+                    <div className="text-xs text-gray-500 mb-1">
+                      Question {index + 1} of {questions.length}
                     </div>
-                  ))
-                ) : (
-                  <div className="py-3 text-sm text-gray-400 text-center italic">
-                    No responses yet
+                    <div className="flex items-center gap-2">
+                      <h2 className="text-base font-medium">{label}</h2>
+                      {question.is_required && (
+                        <span className="text-xs text-red-600">*</span>
+                      )}
+                    </div>
                   </div>
-                )}
+                  <ChevronRight
+                    className={`h-5 w-5 text-gray-400 shrink-0 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+                  />
+                </div>
               </div>
-            )}
-          </div>
-        );
-      })}
+
+              {isExpanded && (
+                <div className="py-3 px-4 bg-gray-50/50 space-y-3">
+                  {responses.length > 0 ? (
+                    responses.map((response, idx) => (
+                      <div
+                        key={idx}
+                        className="py-3 px-4 bg-white/80 backdrop-blur-sm rounded-lg text-sm text-gray-800 shadow-sm hover:shadow-md transition-shadow"
+                      >
+                        {String(response)}
+                      </div>
+                    ))
+                  ) : (
+                    <div className="py-3 text-sm text-gray-400 text-center italic">
+                      No responses yet
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })
+      )}
     </div>
   );
 }

--- a/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
@@ -217,6 +217,7 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
   const [isEditMode, setIsEditMode] = useState(false);
   const [draftQuestions, setDraftQuestions] = useState<DraftQuestion[]>([]);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor));
 
@@ -312,11 +313,19 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
   };
 
   const saveForm = async () => {
+    setSaveError(null);
+
+    const emptyIndex = draftQuestions.findIndex((q) => q.label.trim() === "");
+    if (emptyIndex !== -1) {
+      setSaveError(`Question ${emptyIndex + 1} has no text.`);
+      return;
+    }
+
     setSaving(true);
     try {
       const payload = draftQuestions.map((q) => ({
         question_text: encodeQuestionText(
-          q.label,
+          q.label.trim(),
           q.type,
           q.options.length > 0 ? q.options : null,
         ),
@@ -334,13 +343,15 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
 
       if (!res.ok) {
         const json = await res.json();
-        alert(`Failed to save: ${json.error ?? "Unknown error"}`);
+        setSaveError(json.error ?? "Failed to save. Please try again.");
         return;
       }
 
       const json = await res.json();
       setQuestions(json.questions ?? []);
       setIsEditMode(false);
+    } catch {
+      setSaveError("Network error. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -368,7 +379,10 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setIsEditMode(false)}
+              onClick={() => {
+                setIsEditMode(false);
+                setSaveError(null);
+              }}
               disabled={saving}
             >
               Cancel
@@ -378,6 +392,12 @@ export function QuestionsTab({ openingId, orgId }: QuestionsTabProps) {
             </Button>
           </div>
         </div>
+
+        {saveError && (
+          <p className="text-sm text-red-600 bg-red-50 rounded-lg px-4 py-3">
+            {saveError}
+          </p>
+        )}
 
         <DndContext
           sensors={sensors}

--- a/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/components/QuestionsTab.tsx
@@ -6,7 +6,7 @@ import {
   ChevronRight,
   Plus,
   Trash01,
-  GripVertical,
+  GridDotsVerticalCenter,
 } from "@untitled-ui/icons-react";
 import { parseQuestionText, encodeQuestionText } from "@/lib/question-utils";
 import type { FieldType } from "@/lib/question-utils";
@@ -103,7 +103,7 @@ function SortableQuestionCard({
           className="mt-2 cursor-grab text-gray-400 hover:text-gray-600 shrink-0"
           aria-label="Drag to reorder"
         >
-          <GripVertical className="w-4 h-4" />
+          <GridDotsVerticalCenter className="w-4 h-4" />
         </button>
 
         <div className="flex-1 space-y-2">

--- a/app/protected/org/[orgId]/opening/[openingId]/page.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/page.tsx
@@ -124,13 +124,14 @@ export default async function OpeningOverviewPage({
           />
         );
       case "questions":
-        return <QuestionsTab openingId={openingId} />;
+        return <QuestionsTab openingId={openingId} orgId={orgId} />;
       case "overview":
         return (
           <OverviewTab
             applicants={applicants}
             orgId={orgId}
             openingId={openingId}
+            openingStatus={openingData?.status ?? null}
           />
         );
       case "upload":

--- a/app/protected/org/[orgId]/opening/[openingId]/page.tsx
+++ b/app/protected/org/[orgId]/opening/[openingId]/page.tsx
@@ -124,7 +124,13 @@ export default async function OpeningOverviewPage({
           />
         );
       case "questions":
-        return <QuestionsTab openingId={openingId} orgId={orgId} />;
+        return (
+          <QuestionsTab
+            openingId={openingId}
+            orgId={orgId}
+            applicationLink={openingData?.application_link ?? null}
+          />
+        );
       case "overview":
         return (
           <OverviewTab
@@ -132,6 +138,7 @@ export default async function OpeningOverviewPage({
             orgId={orgId}
             openingId={openingId}
             openingStatus={openingData?.status ?? null}
+            applicationLink={openingData?.application_link ?? null}
           />
         );
       case "upload":
@@ -181,7 +188,7 @@ export default async function OpeningOverviewPage({
 
       {/* Tabs */}
       <Suspense fallback={<div className="h-12" />}>
-        <OpeningTabs />
+        <OpeningTabs useNativeForm={!openingData?.application_link} />
       </Suspense>
 
       {/* Tab content */}

--- a/components/edit-members-dialog.tsx
+++ b/components/edit-members-dialog.tsx
@@ -6,6 +6,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -320,6 +321,9 @@ export function EditMembersDialog({ orgId }: { orgId: string }) {
             </DialogClose>
           </div>
           <DialogTitle className="sr-only">Edit members</DialogTitle>
+          <DialogDescription className="sr-only">
+            Add or remove organization members and change their roles.
+          </DialogDescription>
           <div className="relative" ref={searchContainerRef}>
             <Input
               placeholder="Add members"

--- a/components/edit-opening-dialog.tsx
+++ b/components/edit-opening-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Dialog,
@@ -36,17 +36,35 @@ export function EditOpeningDialog({
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [title, setTitle] = useState(initialData.title);
   const [description, setDescription] = useState(initialData.description || "");
+  const [useNativeForm, setUseNativeForm] = useState(
+    !initialData.application_link,
+  );
   const [applicationLink, setApplicationLink] = useState(
     initialData.application_link || "",
   );
   const [closesAt, setClosesAt] = useState(initialData.closes_at || "");
   const [status, setStatus] = useState(initialData.status);
 
+  // Reset form state whenever the dialog opens so we always show fresh data
+  useEffect(() => {
+    if (open) {
+      setSaveError(null);
+      setTitle(initialData.title);
+      setDescription(initialData.description || "");
+      setUseNativeForm(!initialData.application_link);
+      setApplicationLink(initialData.application_link || "");
+      setClosesAt(initialData.closes_at || "");
+      setStatus(initialData.status);
+    }
+  }, [open, initialData]);
+
   const handleSave = async () => {
     if (!title.trim()) return;
     setSaving(true);
+    setSaveError(null);
     try {
       const res = await fetch(`/api/org/${orgId}/openings/${openingId}`, {
         method: "PATCH",
@@ -54,7 +72,7 @@ export function EditOpeningDialog({
         body: JSON.stringify({
           title,
           description,
-          ...(initialData.application_link ? { application_link: applicationLink } : {}),
+          application_link: useNativeForm ? null : applicationLink || null,
           closes_at: closesAt || null,
           status,
         }),
@@ -62,7 +80,12 @@ export function EditOpeningDialog({
       if (res.ok) {
         setOpen(false);
         router.refresh();
+      } else {
+        const data = await res.json().catch(() => null);
+        setSaveError(data?.error || "Failed to save changes. Please try again.");
       }
+    } catch {
+      setSaveError("An unexpected error occurred. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -100,17 +123,48 @@ export function EditOpeningDialog({
               rows={3}
             />
           </div>
-          {initialData.application_link && (
-            <div className="space-y-2">
-              <Label htmlFor="edit-link">Application Link</Label>
+          <div className="space-y-2">
+            <Label>Application Method</Label>
+            <div className="flex rounded-lg border border-gray-200 w-fit overflow-hidden">
+              <button
+                type="button"
+                onClick={() => {
+                  setUseNativeForm(true);
+                  setApplicationLink("");
+                }}
+                className={`px-4 py-2 text-sm font-medium transition-colors ${
+                  useNativeForm
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-white text-gray-600 hover:bg-gray-50"
+                }`}
+              >
+                Native Form
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setUseNativeForm(false);
+                  if (!applicationLink) setApplicationLink("https://");
+                }}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-l border-gray-200 ${
+                  !useNativeForm
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-white text-gray-600 hover:bg-gray-50"
+                }`}
+              >
+                Google Forms
+              </button>
+            </div>
+            {!useNativeForm && (
               <Input
                 id="edit-link"
+                type="url"
                 value={applicationLink}
                 onChange={(e) => setApplicationLink(e.target.value)}
-                placeholder="https://..."
+                placeholder="https://forms.google.com/..."
               />
-            </div>
-          )}
+            )}
+          </div>
           <div className="space-y-2">
             <Label htmlFor="edit-closes">Closes At</Label>
             <Input
@@ -137,6 +191,11 @@ export function EditOpeningDialog({
               ))}
             </div>
           </div>
+          {saveError && (
+            <p className="text-sm text-red-600 rounded-lg bg-red-50 px-4 py-3">
+              {saveError}
+            </p>
+          )}
           <div className="flex justify-end gap-2 mt-2">
             <Button variant="outline" onClick={() => setOpen(false)}>
               Cancel

--- a/components/edit-opening-dialog.tsx
+++ b/components/edit-opening-dialog.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -53,7 +54,7 @@ export function EditOpeningDialog({
         body: JSON.stringify({
           title,
           description,
-          application_link: applicationLink,
+          ...(initialData.application_link ? { application_link: applicationLink } : {}),
           closes_at: closesAt || null,
           status,
         }),
@@ -77,6 +78,9 @@ export function EditOpeningDialog({
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Edit Opening</DialogTitle>
+          <DialogDescription className="sr-only">
+            Edit the details of this opening.
+          </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-4 mt-2">
           <div className="space-y-2">
@@ -96,15 +100,17 @@ export function EditOpeningDialog({
               rows={3}
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="edit-link">Application Link</Label>
-            <Input
-              id="edit-link"
-              value={applicationLink}
-              onChange={(e) => setApplicationLink(e.target.value)}
-              placeholder="https://..."
-            />
-          </div>
+          {initialData.application_link && (
+            <div className="space-y-2">
+              <Label htmlFor="edit-link">Application Link</Label>
+              <Input
+                id="edit-link"
+                value={applicationLink}
+                onChange={(e) => setApplicationLink(e.target.value)}
+                placeholder="https://..."
+              />
+            </div>
+          )}
           <div className="space-y-2">
             <Label htmlFor="edit-closes">Closes At</Label>
             <Input

--- a/components/rubric-editor-dialog.tsx
+++ b/components/rubric-editor-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -109,6 +110,9 @@ export function RubricEditorDialog({
       <DialogContent className="sm:max-w-[500px] max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Edit Scoring Rubric</DialogTitle>
+          <DialogDescription className="sr-only">
+            Define the skills and maximum scores for evaluating candidates.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4 py-4">

--- a/lib/question-utils.ts
+++ b/lib/question-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Utilities for encoding/decoding question metadata in the question_text column.
+ *
+ * Since the DB schema has no field_type or options columns, we encode rich
+ * question metadata as JSON inside question_text. Plain-string question_text
+ * values (from CSV uploads) are handled transparently via the parser.
+ *
+ * Format for form-builder questions:
+ *   {"label":"Tell us about yourself","type":"textarea","options":null}
+ *
+ * The `label` value is used as the key in form_responses (matching the
+ * CSV-upload convention where question_text IS the form_responses key).
+ */
+
+export type FieldType = "text" | "textarea" | "select" | "checkbox" | "url";
+
+export interface ParsedQuestion {
+  label: string;
+  type: FieldType;
+  options: string[] | null;
+}
+
+/**
+ * Parses a question_text value, handling both plain strings and JSON-encoded
+ * form-builder questions.
+ */
+export function parseQuestionText(text: string): ParsedQuestion {
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed.label === "string") {
+      return {
+        label: parsed.label,
+        type: (parsed.type as FieldType) || "text",
+        options: Array.isArray(parsed.options) ? parsed.options : null,
+      };
+    }
+  } catch {
+    // Not JSON — treat as plain text (CSV-uploaded question)
+  }
+  return { label: text, type: "text", options: null };
+}
+
+/**
+ * Encodes a form-builder question as a question_text string.
+ * Simple text questions with no options are stored as plain strings for
+ * backwards compatibility.
+ */
+export function encodeQuestionText(
+  label: string,
+  type: FieldType,
+  options: string[] | null,
+): string {
+  if (type === "text" && !options) return label;
+  return JSON.stringify({ label, type, options: options ?? null });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-const PUBLIC_PATHS = ["/", "/auth", "/login", "/discover"];
+const PUBLIC_PATHS = ["/", "/auth", "/login", "/discover", "/apply"];
 const PUBLIC_GET_ROUTES = ["/api/openings"];
 
 function isPublicPath(pathname: string): boolean {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -138,9 +137,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -393,9 +392,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -403,9 +402,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
-      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -421,13 +420,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
-      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -443,13 +442,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.3"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -463,9 +462,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -479,11 +478,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
-      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -495,11 +497,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
-      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -511,11 +516,33 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
-      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -527,11 +554,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
-      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -543,11 +573,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
-      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -559,11 +592,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
-      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -575,11 +611,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
-      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -591,12 +630,15 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
-      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -609,15 +651,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.3"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
-      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -631,16 +676,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.3"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
-      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -653,16 +701,44 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.3"
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
-      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -675,15 +751,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.3"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
-      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -697,16 +776,19 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.3"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
-      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -719,15 +801,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
-      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -741,20 +826,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
-      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.5.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -764,9 +849,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
-      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
       "cpu": [
         "arm64"
       ],
@@ -783,9 +868,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
-      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -802,9 +887,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
-      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -885,9 +970,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.1.tgz",
+      "integrity": "sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -901,9 +986,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.1.tgz",
+      "integrity": "sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==",
       "cpu": [
         "arm64"
       ],
@@ -917,9 +1002,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.1.tgz",
+      "integrity": "sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==",
       "cpu": [
         "x64"
       ],
@@ -933,11 +1018,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.1.tgz",
+      "integrity": "sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -949,11 +1037,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.1.tgz",
+      "integrity": "sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -965,11 +1056,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.1.tgz",
+      "integrity": "sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -981,11 +1075,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.1.tgz",
+      "integrity": "sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -997,9 +1094,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.1.tgz",
+      "integrity": "sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==",
       "cpu": [
         "arm64"
       ],
@@ -1013,9 +1110,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.1.tgz",
+      "integrity": "sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==",
       "cpu": [
         "x64"
       ],
@@ -2026,7 +2123,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.75.1.tgz",
       "integrity": "sha512-GEPVBvjQimcMd9z5K1eTKTixTRb6oVbudoLQ9JKqTUJnR6GQdBU4OifFZean1AnHfsQwtri1fop2OWwsMv019w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.75.1",
         "@supabase/functions-js": "2.75.1",
@@ -2141,7 +2237,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2152,7 +2247,6 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2211,7 +2305,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2356,9 +2449,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2726,7 +2819,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2745,9 +2837,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3102,12 +3194,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.17.tgz",
-      "integrity": "sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==",
+      "version": "2.10.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
+      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bin-links": {
@@ -3140,9 +3235,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3183,7 +3278,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3877,7 +3971,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3966,7 +4059,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4068,7 +4160,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4495,9 +4586,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4866,13 +4957,13 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+      "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": ">= 14"
@@ -5382,7 +5473,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5710,14 +5800,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.1.tgz",
+      "integrity": "sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.1",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -5729,15 +5819,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.1",
+        "@next/swc-darwin-x64": "16.2.1",
+        "@next/swc-linux-arm64-gnu": "16.2.1",
+        "@next/swc-linux-arm64-musl": "16.2.1",
+        "@next/swc-linux-x64-gnu": "16.2.1",
+        "@next/swc-linux-x64-musl": "16.2.1",
+        "@next/swc-win32-arm64-msvc": "16.2.1",
+        "@next/swc-win32-x64-msvc": "16.2.1",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -6128,9 +6218,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6190,7 +6280,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6350,7 +6439,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6431,7 +6519,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6441,7 +6528,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6801,16 +6887,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
-      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.0",
-        "semver": "^7.7.2"
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -6819,28 +6905,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.4",
-        "@img/sharp-darwin-x64": "0.34.4",
-        "@img/sharp-libvips-darwin-arm64": "1.2.3",
-        "@img/sharp-libvips-darwin-x64": "1.2.3",
-        "@img/sharp-libvips-linux-arm": "1.2.3",
-        "@img/sharp-libvips-linux-arm64": "1.2.3",
-        "@img/sharp-libvips-linux-ppc64": "1.2.3",
-        "@img/sharp-libvips-linux-s390x": "1.2.3",
-        "@img/sharp-libvips-linux-x64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
-        "@img/sharp-linux-arm": "0.34.4",
-        "@img/sharp-linux-arm64": "0.34.4",
-        "@img/sharp-linux-ppc64": "0.34.4",
-        "@img/sharp-linux-s390x": "0.34.4",
-        "@img/sharp-linux-x64": "0.34.4",
-        "@img/sharp-linuxmusl-arm64": "0.34.4",
-        "@img/sharp-linuxmusl-x64": "0.34.4",
-        "@img/sharp-wasm32": "0.34.4",
-        "@img/sharp-win32-arm64": "0.34.4",
-        "@img/sharp-win32-ia32": "0.34.4",
-        "@img/sharp-win32-x64": "0.34.4"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -7167,16 +7255,16 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.77.0",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.77.0.tgz",
-      "integrity": "sha512-CTjEkiuXV3ITyhYZm0k3dx/jW4qGTGxVNjInQWk2KO+/dLCpNS6dvX/NKKZQHMb3O9Pyj/3w0XKGusliCizbBg==",
+      "version": "2.84.5",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.84.5.tgz",
+      "integrity": "sha512-quguD5MJVcbbMie35d++BaV3ejXyTTZQIz3zH/z485bLxcEl+wC1EttGboq9Snukzv6sDoQkshXYga+6K4SQwA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bin-links": "^6.0.0",
-        "https-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^8.0.0",
         "node-fetch": "^3.3.2",
-        "tar": "7.5.10"
+        "tar": "7.5.13"
       },
       "bin": {
         "supabase": "bin/supabase"
@@ -7316,9 +7404,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
-      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -7390,12 +7478,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7558,7 +7645,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/supabase/migrations/20260330_transactional_functions.sql
+++ b/supabase/migrations/20260330_transactional_functions.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- 1. create_org_with_admin
+--    Atomically creates an org and assigns the creator as admin.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION create_org_with_admin(
+  org_name TEXT,
+  org_description TEXT,
+  creator_id UUID
+)
+RETURNS UUID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  new_org_id UUID;
+BEGIN
+  INSERT INTO orgs (name, description)
+    VALUES (org_name, org_description)
+    RETURNING id INTO new_org_id;
+
+  INSERT INTO org_members (org_id, user_id, role)
+    VALUES (new_org_id, creator_id, 'admin');
+
+  RETURN new_org_id;
+END;
+$$;
+
+
+-- =============================================================================
+-- 2. replace_opening_questions
+--    Atomically deletes existing questions and inserts new ones.
+--    Accepts a JSON array: [{ "question_text": "...", "is_required": bool, "sort_order": int }]
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION replace_opening_questions(
+  target_opening_id UUID,
+  questions_json JSONB
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  inserted JSONB;
+BEGIN
+  -- Delete existing questions for this opening
+  DELETE FROM questions WHERE opening_id = target_opening_id;
+
+  -- If the array is empty or null, return early
+  IF questions_json IS NULL OR jsonb_array_length(questions_json) = 0 THEN
+    RETURN '[]'::JSONB;
+  END IF;
+
+  -- Insert new questions and capture the result
+  WITH inserted_rows AS (
+    INSERT INTO questions (opening_id, question_text, is_required, sort_order)
+    SELECT
+      target_opening_id,
+      (elem->>'question_text')::TEXT,
+      (elem->>'is_required')::BOOLEAN,
+      (elem->>'sort_order')::INT
+    FROM jsonb_array_elements(questions_json) AS elem
+    RETURNING *
+  )
+  SELECT jsonb_agg(row_to_json(inserted_rows)) INTO inserted FROM inserted_rows;
+
+  RETURN COALESCE(inserted, '[]'::JSONB);
+END;
+$$;

--- a/types/app.ts
+++ b/types/app.ts
@@ -1,4 +1,7 @@
 import { Database } from "./supabase";
+import type { FieldType } from "@/lib/question-utils";
+
+export type { FieldType };
 
 // -- Helper Types --
 export type Tables<T extends keyof Database["public"]["Tables"]> =
@@ -24,6 +27,20 @@ export type ApplicationStatus = Enums<"status">;
 export type Score = Enums<"score">;
 export type OpeningStatus = Enums<"opening_status">;
 export type OrgRole = Enums<"org_role">;
+
+// -- Rich question type (decoded from question_text) --
+export interface TypedQuestion {
+  id: string;
+  opening_id: string;
+  /** Stored in DB as plain string or JSON-encoded string */
+  question_text: string;
+  /** Decoded display label (= form_responses key) */
+  label: string;
+  type: FieldType;
+  options: string[] | null;
+  is_required: boolean | null;
+  sort_order: number | null;
+}
 
 // -- Joined / Aggregate Types --
 


### PR DESCRIPTION
## Summary

Adds a native form builder so admins can build application forms directly in owlrecruit, share a link with applicants, and receive submissions without needing to export/import CSVs from Google Forms.

- **Admin**: Opens an opening → Questions tab → "Edit Form" → adds/reorders/deletes questions (short answer, long answer, dropdown, checkboxes, URL) → saves
- **Admin**: When opening is `open`, Overview tab shows a shareable form link (`/apply/[openingId]`)
- **Applicant**: Visits link, signs in with Rice Google account, fills out form, submits
- **Result**: Application appears in admin's Kanban board as "Applied" — same as CSV uploads

CSV upload continues to work unchanged.

---

## Does this require a Supabase schema migration?

**No — no migration is required for this PR to function.**

### How it works without migration

The `questions` table has a `question_text TEXT` column. Form-builder questions encode their type metadata as JSON inside this column:

```
Plain text (CSV-uploaded):   "Tell us about yourself"
Form-builder question:       {"label":"Tell us about yourself","type":"textarea","options":null}
```

A `parseQuestionText()` helper (`lib/question-utils.ts`) handles both formats transparently. The key used in `form_responses` is always the decoded plain label — backwards compatible with all existing CSV-uploaded applications.

### Optional future migration (recommended once Supabase is unpaused)

If you want a cleaner schema with dedicated columns:

```sql
ALTER TABLE questions
  ADD COLUMN field_type TEXT NOT NULL DEFAULT 'text',
  ADD COLUMN options     JSONB DEFAULT NULL;
```

After running this migration, you could migrate data out of the `question_text` JSON encoding and update the question-utils helpers to read from the new columns. This is **purely optional** — the current implementation works correctly without it.

---

## New files

| File | Purpose |
|------|---------|
| `lib/question-utils.ts` | `parseQuestionText` / `encodeQuestionText` helpers |
| `app/api/org/[orgId]/opening/[openingId]/questions/route.ts` | `GET` list questions; `PATCH` save full form (admin) |
| `app/api/openings/[openingId]/route.ts` | Public `GET` — opening metadata + questions for apply page |
| `app/api/openings/[openingId]/apply/route.ts` | `POST` — submit application (auth required, `@rice.edu` only) |
| `app/apply/layout.tsx` | Minimal centered layout for apply page |
| `app/apply/[openingId]/page.tsx` | Server component — fetches opening + questions |
| `app/apply/[openingId]/ApplyForm.tsx` | Client form with sign-in gate, all field types, submit |

## Modified files

| File | Change |
|------|--------|
| `middleware.ts` | Add `/apply` to `PUBLIC_PATHS` |
| `types/app.ts` | Add `TypedQuestion` interface + re-export `FieldType` |
| `QuestionsTab.tsx` | Add edit/view mode toggle, drag-to-reorder form builder |
| `OverviewTab.tsx` | Show shareable form link when `opening.status === "open"` |
| `page.tsx` (opening) | Pass `orgId` to `QuestionsTab`, `openingStatus` to `OverviewTab` |

---

## Test plan

- [x] Admin: opening → Questions tab → "Edit Form" → add questions (try each field type) → reorder with drag → mark required → Save → verify in Supabase `questions` table
- [x] Admin: set opening status to `open` → Overview tab → verify form link card appears, copy works
- [x] Applicant: visit `/apply/[openingId]` unauthenticated → form shows, sign-in button visible
- [x] Applicant: sign in with Rice Google account → form renders with all questions
- [x] Applicant: fill out and submit → success state shown, application appears in admin Kanban as "Applied"
- [x] Submit again → 409 duplicate error shown
- [x] Non-`@rice.edu` account → friendly error shown
- [x] CSV upload still works end-to-end (existing flow unchanged)