### PR TITLE
Changed Google OAuth client ID to an env var and created .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,31 @@
-# Supabase
-NEXT_PUBLIC_SUPABASE_URL=                          # Your Supabase project URL
-NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=              # Your Supabase publishable (anon) key
 
-# Google OAuth
-# Client ID is public — safe to expose in the browser
-NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=                # Google OAuth client ID (from Google Cloud Console)
-# Used by Supabase local CLI (config.toml env substitution)
-SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=           # Same Google OAuth client ID
-# Client secret — keep private, never commit
-SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET=       # Google OAuth client secret (from Google Cloud Console)
+# REQUIRED — app will not run without these
+# Supabase project credentials (find in Supabase dashboard → Project Settings → API)
+NEXT_PUBLIC_SUPABASE_URL=                          # e.g. https://xxxx.supabase.co
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=              # Supabase anon/publishable key
+
+# Google OAuth (find in Google Cloud Console → APIs & Services → Credentials)
+NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=                # OAuth 2.0 client ID (safe to expose publicly)
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=           # Same client ID — used by Supabase CLI locally
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET=       # OAuth client secret (keep private)
+
+
+# OPTIONAL — only needed if you enable the corresponding features
+
+# Supabase Studio AI (for local dev only)
+# OPENAI_API_KEY=
+
+# Twilio SMS (enable in config.toml [auth.sms.twilio])
+# SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN=
+
+# Apple OAuth (enable in config.toml [auth.external.apple])
+# SUPABASE_AUTH_EXTERNAL_APPLE_SECRET=
+
+# SendGrid email (enable in config.toml [auth.email.smtp])
+# SENDGRID_API_KEY=
+
+# S3 storage (enable in config.toml [experimental])
+# S3_HOST=
+# S3_REGION=
+# S3_ACCESS_KEY=
+# S3_SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=                          # Your Supabase project URL
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=              # Your Supabase publishable (anon) key
+
+# Google OAuth
+# Client ID is public — safe to expose in the browser
+NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=                # Google OAuth client ID (from Google Cloud Console)
+# Used by Supabase local CLI (config.toml env substitution)
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=           # Same Google OAuth client ID
+# Client secret — keep private, never commit
+SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET=       # Google OAuth client secret (from Google Cloud Console)

--- a/app/auth/sign-up/sign-up-google.tsx
+++ b/app/auth/sign-up/sign-up-google.tsx
@@ -40,7 +40,7 @@ export default function SignUpGoogleBtn() {
         <>
             <Script src="https://accounts.google.com/gsi/client" strategy="afterInteractive" />
             <div id="g_id_onload"
-              data-client_id="530339823745-p2p8i1r4e6ki8f1ra93aar28n5pil04f.apps.googleusercontent.com"
+              data-client_id={process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID}
               data-context="signup"
               data-ux_mode="popup"
               data-callback="handleSignInWithGoogle"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -200,7 +200,7 @@ otp_expiry = 3600
 
 [auth.external.google]
 enabled = true
-client_id = "530339823745-p2p8i1r4e6ki8f1ra93aar28n5pil04f.apps.googleusercontent.com"
+client_id = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID)"
 secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_SECRET)"
 skip_nonce_check = false
 


### PR DESCRIPTION
- move Google OAuth client ID to env var: removes hardcoded client ID from sign-up-google.tsx and  config.toml

- new .env.example documenting all env vars for deployment